### PR TITLE
Workaround linuxppc dev

### DIFF
--- a/pre-new
+++ b/pre-new
@@ -68,7 +68,7 @@ sync()
 initialize()
 {
     local gitdir=$base/git/$1
-    local epoch=$(ls -v $gitdir/ | tail -n1)
+    local epoch=$(ls -v $gitdir/ 2>/dev/null | tail -n1)
     local url=$(getvar $base/sources $1 url)
     local since=$(getvar $base/sources $1 since)
 

--- a/pre-new
+++ b/pre-new
@@ -85,8 +85,17 @@ initialize()
 	echo "  epoch$epoch: initial import" >&2
 	if ! git --git-dir=$gitdir/$epoch fetch --quiet \
 	     --shallow-since="$since" 2>/dev/null; then
-	    echo "    no messages in range." >&2
-	    continue
+	    if [ $epoch -eq 0 ]; then
+		# retry without separate git fetch, e.g. linuxppc-dev
+		rm -rf "${gitdir:?}/$epoch"
+		if ! git clone --mirror --shallow-since="$since" "$url/0" "$gitdir/0"; then
+		    echo "    failed cloning repo $url"
+		    continue
+		fi
+	    else
+		echo "    no messages in range." >&2
+		continue
+	    fi
 	fi
 
 	import $1 $gitdir/$epoch master


### PR DESCRIPTION
Adding linuxppc-dev to my .lore/sources file, like so:

```
[netdev]
url=https://lore.kernel.org/netdev

[mtd]
url=https://lore.kernel.org/linux-mtd

[ppc]
url=https://lore.kernel.org/linuxppc-dev
```

Causes notmuch-lore to fail cloning & fetching the last three months with the followoing error message:

> ppc: initialize (https://lore.kernel.org/linuxppc-dev)
> Cloning into bare repository '/home/joachim/mail/.notmuch/.lore/git/ppc/0'...
> remote: Enumerating objects: 3, done.
> remote: Counting objects: 100% (3/3), done.
> remote: Compressing objects: 100% (2/2), done.
> remote: Total 3 (delta 0), reused 0 (delta 0), pack-reused 0
> Unpacking objects: 100% (3/3), 7.59 KiB | 2.53 MiB/s, done.
> epoch0: git --git-dir=/home/joachim/mail/.notmuch/.lore/git/ppc/0 fetch --shallow-since="3 months ago"
> **fatal: the remote end hung up unexpectedly**
> no messages in range.

The included patch is a workaround that, in a dedicated error handling step for epoch 0, does a plain shallow clone using `--shallow-since"$since"`.

It's not a pretty fix, but it works.